### PR TITLE
Fix typo in design canvas

### DIFF
--- a/docs/design.canvas
+++ b/docs/design.canvas
@@ -1,7 +1,7 @@
 {
 	"nodes":[
 		{"id":"fffe97f3850adf71","type":"file","file":"docs/vision.md","x":-160,"y":-400,"width":250,"height":180},
-		{"id":"25232d277ee2bdfa","type":"text","text":"User Stores","x":-160,"y":-180,"width":250,"height":70},
+                {"id":"25232d277ee2bdfa","type":"text","text":"User Stories","x":-160,"y":-180,"width":250,"height":70},
 		{"id":"8ab96e8cd596f1ac","type":"text","text":"Backlog ","x":-160,"y":-60,"width":250,"height":60}
 	],
 	"edges":[]


### PR DESCRIPTION
## Summary
- fix typo `User Stores` → `User Stories` in design.canvas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f6c3bd1c0832f87428c9db192aa6d